### PR TITLE
Resolve an issue that caused crashes in DelegateProxyType

### DIFF
--- a/Sources/RxDataSources-Texture/ASCollectionNode/ASCollectionNode+Rx.swift
+++ b/Sources/RxDataSources-Texture/ASCollectionNode/ASCollectionNode+Rx.swift
@@ -84,9 +84,11 @@ extension Reactive where Base: ASCollectionNode {
    - parameter delegate: Delegate object
    - returns: Disposable object that can be used to unbind the delegate.
    */
-  public func setDelegate(_ delegate: ASCollectionDelegate)
-    -> Disposable {
-      return RxASCollectionDelegateProxy.installForwardDelegate(delegate, retainDelegate: false, onProxyForObject: self.base)
+  public func setDelegate(_ delegate: ASCollectionDelegate) -> Disposable {
+    return ScheduledDisposable(
+      scheduler: MainScheduler.instance,
+      disposable: RxASCollectionDelegateProxy.installForwardDelegate(delegate, retainDelegate: false, onProxyForObject: self.base)
+    )
   }
 
   /// Reactive wrapper for `contentOffset`.

--- a/Sources/RxDataSources-Texture/ASCollectionNode/ASCollectionNode+Rx.swift
+++ b/Sources/RxDataSources-Texture/ASCollectionNode/ASCollectionNode+Rx.swift
@@ -70,9 +70,11 @@ extension Reactive where Base: ASCollectionNode {
    - parameter dataSource: Data source object.
    - returns: Disposable object that can be used to unbind the data source.
    */
-  public func setDataSource(_ dataSource: ASCollectionDataSource)
-    -> Disposable {
-      return RxASCollectionDataSourceProxy.installForwardDelegate(dataSource, retainDelegate: false, onProxyForObject: self.base)
+  public func setDataSource(_ dataSource: ASCollectionDataSource) -> Disposable {
+    return ScheduledDisposable(
+      scheduler: MainScheduler.instance,
+      disposable: RxASCollectionDataSourceProxy.installForwardDelegate(dataSource, retainDelegate: false, onProxyForObject: self.base)
+    )
   }
 
   /**

--- a/Sources/RxDataSources-Texture/ASTableNode/ASTableNode+Rx.swift
+++ b/Sources/RxDataSources-Texture/ASTableNode/ASTableNode+Rx.swift
@@ -80,9 +80,11 @@ extension Reactive where Base: ASTableNode {
    - parameter dataSource: Data source object.
    - returns: Disposable object that can be used to unbind the data source.
    */
-  public func setDataSource(_ dataSource: ASTableDataSource)
-    -> Disposable {
-      return RxASTableDataSourceProxy.installForwardDelegate(dataSource, retainDelegate: false, onProxyForObject: self.base)
+  public func setDataSource(_ dataSource: ASTableDataSource) -> Disposable {
+    return ScheduledDisposable(
+      scheduler: MainScheduler.instance,
+      disposable: RxASTableDataSourceProxy.installForwardDelegate(dataSource, retainDelegate: false, onProxyForObject: self.base)
+    )
   }
 
   /**

--- a/Sources/RxDataSources-Texture/ASTableNode/ASTableNode+Rx.swift
+++ b/Sources/RxDataSources-Texture/ASTableNode/ASTableNode+Rx.swift
@@ -94,9 +94,11 @@ extension Reactive where Base: ASTableNode {
    - parameter delegate: Delegate object
    - returns: Disposable object that can be used to unbind the delegate.
    */
-  public func setDelegate(_ delegate: ASTableDelegate)
-    -> Disposable {
-      return RxASTableDelegateProxy.installForwardDelegate(delegate, retainDelegate: false, onProxyForObject: self.base)
+  public func setDelegate(_ delegate: ASTableDelegate) -> Disposable {
+    return ScheduledDisposable(
+      scheduler: MainScheduler.instance,
+      disposable: RxASTableDelegateProxy.installForwardDelegate(delegate, retainDelegate: false, onProxyForObject: self.base)
+    )
   }
 
   /// Reactive wrapper for `contentOffset`.


### PR DESCRIPTION
`setDelegate`, `setDataSource` methods returns `ScheduledDisposable`(Main Scheduler)